### PR TITLE
Enabled kexecing using kexec_load

### DIFF
--- a/pkg/boot/pe.go
+++ b/pkg/boot/pe.go
@@ -42,6 +42,7 @@ func (PEImage) ExecutionInfo(log *log.Logger) {
 }
 
 const M16 = 0x1000000
+const KEXEC_RUN_PE = 0x00000004
 
 // Execute implements OSImage.Execute.
 func (p *PEImage) Execute() error {
@@ -78,7 +79,7 @@ func (p *PEImage) Execute() error {
 		entry = uintptr(oh.AddressOfEntryPoint)
 	}
 
-	if err := kexec.Load(M16+entry, segment, 0); err != nil {
+	if err := kexec.Load(M16+entry, segment, KEXEC_RUN_PE); err != nil {
 		return err
 	}
 	// kexec.Reboot()

--- a/pkg/kexec/kexec_linux_amd64.go
+++ b/pkg/kexec/kexec_linux_amd64.go
@@ -159,6 +159,10 @@ type ErrKexec struct {
 	Errno    syscall.Errno
 }
 
+func (e ErrKexec) Error() string {
+    return "<ErrKexec>"
+}
+
 //
 //
 // Preconditions:


### PR DESCRIPTION
* pkg/kexec/kexec_linux_amd64.go: fixed missing Error() implementation

* pkg/boot/pe.go: passed KEXEC_RUN_PE flag to kexec_load syscall